### PR TITLE
[FIX] GoogleTest docs broken cookbook link

### DIFF
--- a/test/cpp-mocks.cpp
+++ b/test/cpp-mocks.cpp
@@ -3,7 +3,7 @@
 class MockStuff : public Stuff {
 public:
 
-    // https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#making-the-compilation-faster
+    // https://github.com/google/googletest/blob/main/docs/gmock_cook_book.md#making-the-compilation-faster
     MockStuff ();
 
     virtual ~MockStuff();


### PR DESCRIPTION
Current one is broken, this change replaces to a fresh one :)